### PR TITLE
Add actual package name to use-package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ using `use-package`. The following code installs `julia-ts-mode` and selects it
 as the default major mode for Julia files:
 
 ``` emacs-lisp
-(use-package
+(use-package julia-ts-mode
   :ensure t
   :mode "\\.jl$")
 ```


### PR DESCRIPTION
Thanks for creating this experimental package! So glad to see it is available on MELPA now.

This PR simply adds the missing package name for `use-package` in the README.